### PR TITLE
Fix file name from `arduino.h` to `Arduino.h`

### DIFF
--- a/BM1383AGLV/BM1383AGLV.cpp
+++ b/BM1383AGLV/BM1383AGLV.cpp
@@ -23,7 +23,7 @@
 ******************************************************************************/
 //#include <avr/pgmspace.h>
 #include <Wire.h>
-#include "arduino.h"
+#include "Arduino.h"
 #include "BM1383AGLV.h"
 
 BM1383AGLV::BM1383AGLV(void)

--- a/BM1422AGMV/BM1422AGMV.cpp
+++ b/BM1422AGMV/BM1422AGMV.cpp
@@ -23,7 +23,7 @@
 ******************************************************************************/
 //#include <avr/pgmspace.h>
 #include <Wire.h>
-#include "arduino.h"
+#include "Arduino.h"
 #include "BM1422AGMV.h"
 
 BM1422::BM1422(int slave_address)

--- a/KX122/KX122.cpp
+++ b/KX122/KX122.cpp
@@ -23,7 +23,7 @@
 ******************************************************************************/
 //#include <avr/pgmspace.h>
 #include <Wire.h>
-#include "arduino.h"
+#include "Arduino.h"
 #include "KX122.h"
 
 KX122::KX122(int slave_address)

--- a/MK71251-02/MK71251.cpp
+++ b/MK71251-02/MK71251.cpp
@@ -22,7 +22,7 @@
  THE SOFTWARE.
 ******************************************************************************/
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "MK71251.h"
 
 


### PR DESCRIPTION
Fix compile error on linux environment